### PR TITLE
:sparkles: Ignorando status messages

### DIFF
--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -115,6 +115,10 @@ export const eventCodeChat = async (body: any) => {
         return;
       }
 
+      if(body.data.key.remoteJid === 'status@broadcast') {
+        return;
+      }
+
       const getConversion = await createConversation(body);
       const messageType = body.data.key.fromMe ? 'outgoing' : 'incoming';
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -116,6 +116,7 @@ export const eventCodeChat = async (body: any) => {
       }
 
       if(body.data.key.remoteJid === 'status@broadcast') {
+        console.log(`🚨 Ignorando status do whatsapp.`);
         return;
       }
 


### PR DESCRIPTION
Vendo os logs percebi que sempre tinha um erro para criar as mensagens e percebi que sempre ocorria quando era uma atualização de status.

```shell
🎉 Evento recebido de suporte {
  event: 'messages.upsert',
  instance: 'suporte',
  data: {
    key: {
      remoteJid: 'status@broadcast',
      fromMe: false,
      id: '3AD32D19464614B88B20',
      participant: '554491583549@s.whatsapp.net'
    },
    pushName: 'Luis Paulo Garcia',
    message: { imageMessage: [Object] },
    messageTimestamp: 1681816623,
    owner: '554497219212@s.whatsapp.net',
    source: 'ios'
  }
}
ApiError: Generic Error
    at catchErrorCodes (/app/node_modules/@figuro/chatwoot-sdk/dist/core/request.js:229:15)
    at /app/node_modules/@figuro/chatwoot-sdk/dist/core/request.js:257:17
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  url: 'https://chat.likesistemas.com.br/api/v1/accounts/1/contacts',
  status: 422,
  statusText: 'Unprocessable Entity',
  body: {
    message: 'Phone number should be in e164 format',
    attributes: [ 'phone_number' ]
  },
  request: {
    method: 'POST',
    url: '/api/v1/accounts/{account_id}/contacts',
    path: { account_id: 1 },
    body: { inbox_id: 2, name: 'Luis Paulo Garcia', phone_number: '+status' },
    errors: { '400': 'Bad Request Error' }
  }
}
Error: ApiError: Generic Error
    at createConversation (/app/providers/chatwoot/index.js:88:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async eventCodeChat (/app/events/index.js:95:35)
    at async /app/app.js:44:22
```
